### PR TITLE
Allow to set additional color information for special charts

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -258,12 +258,12 @@
 
     function getData (labels, data, colours) {
       return labels.map(function (label, i) {
-        return {
+        return angular.extend({}, colours[i], {
           label: label,
           value: data[i],
           color: colours[i].strokeColor,
           highlight: colours[i].pointHighlightStroke
-        };
+        });
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-chart.js",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "An angular.js wrapper for Chart.js",
   "main": "dist/angular-chart.js",
   "directories": {


### PR DESCRIPTION
The `getDataSets` function copies and extends the colours object.  
This pull request adds the same for the `getData` function.