### PR TITLE
Improve hover event

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -193,10 +193,10 @@
             chart = new ChartJs.Chart(ctx)[type](data, options);
             scope.$emit('create', chart);
 
-            ['hover', 'click'].forEach(function (action) {
-              if (scope[action])
-                cvs[action === 'click' ? 'onclick' : 'onmousemove'] = getEventHandler(scope, chart, action);
-            });
+            // Bind events
+            cvs.onclick = scope.click ? getEventHandler(scope, chart, 'click', false) : angular.noop;
+            cvs.onmousemove = scope.hover ? getEventHandler(scope, chart, 'hover', true) : angular.noop;
+
             if (scope.legend && scope.legend !== 'false') setLegend(elem, chart);
           }
 
@@ -227,13 +227,17 @@
       return carry + val;
     }
 
-    function getEventHandler (scope, chart, action) {
+    function getEventHandler (scope, chart, action, triggerOnlyOnChange) {
+      var lastState = null;
       return function (evt) {
         var atEvent = chart.getPointsAtEvent || chart.getBarsAtEvent || chart.getSegmentsAtEvent;
         if (atEvent) {
           var activePoints = atEvent.call(chart, evt);
-          scope[action](activePoints, evt);
-          scope.$apply();
+          if (triggerOnlyOnChange === false || angular.equals(lastState, activePoints) === false) {
+            lastState = activePoints;
+            scope[action](activePoints, evt);
+            scope.$apply();
+          }
         }
       };
     }


### PR DESCRIPTION
Right now the hover event isn't a hover event but a mousemove event which calls `angular.$apply`.

from http://www.sitepoint.com/understanding-angulars-apply-digest/
> Note: $scope.$apply() automatically calls $rootScope.$digest().

What this means is that while the user is moving his mouse all of the applications scopes are digested many many times per second. (which might cause real performance issues)

This pull requests does **not** change this behaviour (to keep backwards compatibility) but adds a new segmentHover (maybe we could find a better name?) handler which only calls the hover handler if you enter or leave a segment with your mouse.

