### PR TITLE
compare all dataset's length when checking canUpdateChart

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -153,7 +153,8 @@
     function canUpdateChart (newVal, oldVal) {
       if (newVal && oldVal && newVal.length && oldVal.length) {
         return Array.isArray(newVal[0]) ?
-        newVal.length === oldVal.length && newVal[0].length === oldVal[0].length :
+        newVal.length === oldVal.length && newVal.every(function (element, index) {
+          return element.length === oldVal[index].length;}) :
           oldVal.reduce(sum, 0) > 0 ? newVal.length === oldVal.length : false;
       }
       return false;


### PR DESCRIPTION
If I have two dataset in a chart, they were set to **empty array** at the beginning.

First I retrieve the data of first dataset from server, `data[0].length` changed,  it will re-create the chart.

Then I retrieve the data of second dataset from server, since the length of `data[0]` doesn't changed, It won't re-create the chart. It will try to update. But `data[1].length` is `0`, nothing happens.

So I modified the length compare of oldValue and newValue in `canUpdateChart()`. It will compare the length of all datasets now.