### PR TITLE
Add 'autoresize' attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ They all use mostly the same API:
 - `click`: onclick event handler
 - `hover`: onmousemove event handler
 - `legend`: (default: `false`): show legend below the chart
+- `autoresize`: (default: `false`): automatically resize the chart when the browser window size changed
 
 There is another directive `chart-base` that takes an extra attribute `chart-type` to define the type
 dynamically, see [stacked bar example](http://jtblin.github.io/angular-chart.js/examples/stacked-bars.html).

--- a/angular-chart.js
+++ b/angular-chart.js
@@ -89,7 +89,8 @@
           chartType: '=',
           legend: '@',
           click: '=',
-          hover: '='
+          hover: '=',
+          autoresize: '@'
         },
         link: function (scope, elem/*, attrs */) {
           var chart, container = document.createElement('div');
@@ -146,6 +147,11 @@
 
             chart = createChart(chartType, scope, elem);
           }
+
+          angular.element(window).on('resize', function () {
+            if (isEmpty(scope.autoresize) || scope.autoresize == 'false') return;
+            resetChart(true, false);
+          });
         }
       };
     };

--- a/angular-chart.js
+++ b/angular-chart.js
@@ -148,10 +148,11 @@
             chart = createChart(chartType, scope, elem);
           }
 
-          angular.element(window).on('resize', function () {
-            if (isEmpty(scope.autoresize) || scope.autoresize == 'false') return;
-            resetChart(true, false);
-          });
+          if (scope.autoresize === 'true') {
+            angular.element(window).on('resize', function () {
+              resetChart(true, false);
+            });
+          }
         }
       };
     };

--- a/examples/autoresize.html
+++ b/examples/autoresize.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" href="../dist/angular-chart.css">
+<style type="text/css">
+	body{ margin: 0; }
+	.header { width: 100%; height: 52px; background: #333; }
+	.box { width: 90%; margin: auto; padding-top: 20px;}
+	.box canvas { width: 100%; height: 340px; }
+	.box .title { text-align: center; font-size: 14pt; font-weight: bold;}
+</style>
+</head>
+
+<body ng-app="app">
+<div id="header" class="header"></div>
+
+<div id="box1" class="box" ng-controller="lineChartCtrl">
+	<div class="title">Chart with autoresize attribute set true</div>
+    <canvas id="canvas1" class="chart chart-line" data="data" labels="labels" legend="true" series="series" autoresize='true'></canvas>
+</div>
+
+<div id="box2" class="box" ng-controller="lineChartCtrl">
+	<div class="title"><div class="title">Chart without autoresize attribute</div></div>
+	 <canvas id="canvas2" class="chart chart-line" data="data" labels="labels" legend="true" series="series" autoresize='false'></canvas>
+</div>
+
+<script src="../bower_components/angular/angular.min.js"></script>
+<script src="../bower_components/Chart.js/Chart.js"></script>
+<script src="../angular-chart.js"></script>
+
+<script>
+var app = angular.module('app',['chart.js']);
+
+app.config(['ChartJsProvider', function (ChartJsProvider) {
+    ChartJsProvider.setOptions({
+        colours: ['#00ff00', '#FF0000'],
+        responsive: false
+    });
+    ChartJsProvider.setOptions('Line', {
+        datasetFill: false,
+        bezierCurve: false
+    });
+}]);
+
+app.controller('lineChartCtrl', ['$scope', function (scope) {
+	scope.labels = ['January', 'February', 'March', 'April', 'May', 'June', 'July'];
+    scope.series = ['Series A', 'Series B'];
+    scope.data = [
+      [65, 59, 80, 81, 56, 55, 40],
+      [28, 48, 40, 19, 86, 27, 90]
+    ];   
+}]);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Working with ng-view and a parent container with percentage size, the chart can't resize properly.

Add a listener to window resize event and 'autoresize' attribute to resize the chart when the browser window size is changed.
