### PR TITLE
Changed require of chart.js to be in correct case.

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -2,7 +2,7 @@
   'use strict';
   if (typeof exports === 'object') {
     // Node/CommonJS
-    module.exports = factory(require('angular'), require('chart.js'));
+    module.exports = factory(require('angular'), require('Chart.js'));
   }  else if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(['angular', 'chart'], factory);

--- a/dist/angular-chart.js
+++ b/dist/angular-chart.js
@@ -2,7 +2,7 @@
   'use strict';
   if (typeof exports === 'object') {
     // Node/CommonJS
-    module.exports = factory(require('angular'), require('chart.js'));
+    module.exports = factory(require('angular'), require('Chart.js'));
   }  else if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(['angular', 'chart'], factory);


### PR DESCRIPTION
The require name is case sensitive when using debowerify with browserify (not sure which of the two forces case sensitive). We were not able to install angular-chart.js with bower and then use it in our app by requiring it using debowerify and browserify without changing the case to match the name of the dependency exactly.