### PR TITLE
make module factory return a module name instead a module instance as…

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -41,7 +41,8 @@
     .directive('chartRadar', function (ChartJsFactory) { return new ChartJsFactory('Radar'); })
     .directive('chartDoughnut', function (ChartJsFactory) { return new ChartJsFactory('Doughnut'); })
     .directive('chartPie', function (ChartJsFactory) { return new ChartJsFactory('Pie'); })
-    .directive('chartPolarArea', function (ChartJsFactory) { return new ChartJsFactory('PolarArea'); });
+    .directive('chartPolarArea', function (ChartJsFactory) { return new ChartJsFactory('PolarArea'); })
+    .name;
 
   /**
    * Wrapper for chart.js


### PR DESCRIPTION
… angular libraries does

See: https://github.com/angular/bower-angular-animate/blob/fc8c108cbb1d8486f725386b943d35730caf3358/index.js as example:

```javascript
    require('./angular-animate');
    module.exports = 'ngAnimate';
````

So you can do:

```javascript
    module.exports = angular.module('yourModule', [
        require('./yourStuff'),
        require('./moreOfYourStuff'),
        require('angular-animate'),
        require('angular-route'),
        require('angular-chart'),
    ]).name;
```