### PR TITLE
Updated angular-chart.css for stacked bar chart

### DIFF
--- a/dist/angular-chart.css
+++ b/dist/angular-chart.css
@@ -4,6 +4,7 @@
 .pie-legend,
 .radar-legend,
 .polararea-legend,
+.stackedbar-legend,
 .doughnut-legend {
   list-style-type: none;
   margin-top: 5px;
@@ -22,6 +23,7 @@
 .pie-legend li,
 .radar-legend li,
 .polararea-legend li,
+.stackedbar-legend li,
 .doughnut-legend li {
   display: inline-block;
   white-space: nowrap;
@@ -38,6 +40,7 @@
 .pie-legend li span,
 .radar-legend li span,
 .polararea-legend li span,
+.stackedbar-legend li span,
 .doughnut-legend li span {
   display: block;
   position: absolute;


### PR DESCRIPTION
Previously, there was no CSS support for stacked bar chart. So added the below styles:
.stackedbar-legend,
.stackedbar-legend li,
.stackedbar-legend li span