### PR TITLE
Missing attribute in example

### DIFF
--- a/examples/charts.html
+++ b/examples/charts.html
@@ -188,7 +188,7 @@
             </tab>
             <tab heading="Markup">
               <pre><code data-language="html">&lt;canvas id=&quot;bar&quot; class=&quot;chart chart-bar&quot;
-  chart-data=&quot;data&quot; chart-labels=&quot;labels&quot;&gt;
+  chart-data=&quot;data&quot; chart-labels=&quot;labels&quot; chart-series=&quot;series&quot;&gt;
 &lt;/canvas&gt;</code></pre>
             </tab>
             <tab heading="Javascript">


### PR DESCRIPTION
The bar chart example markup should have `chart-series` attribute ;)