### PR TITLE
Check if requires are undefined, otherwise the true case would always fire

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -3,8 +3,8 @@
   if (typeof exports === 'object') {
     // Node/CommonJS
     module.exports = factory(
-      typeof angular ? angular : require('angular'),
-      typeof Chart ? Chart : require('chart.js'));
+      typeof angular !== 'undefined' ? angular : require('angular'),
+      typeof Chart !== 'undefined' ? Chart : require('chart.js'));
   }  else if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(['angular', 'chart'], factory);


### PR DESCRIPTION
I noticed this while minifying, the minifier would put Chart instead of require('chart.js'). Even if chart is undefined, since `typeof Chart === "undefined"`. So `if (typeof Chart)` would eval to true (The string `"undefined"` is truthy) and it would break.