### PR TITLE
Fix docs from colors to colours

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
       </ol>
       <p>You can also use the provider: <code>ChartJsProvider</code> in a <code>.config()</code></p>
       <p><pre><code>(function (ChartJsProvider) {
-  ChartJsProvider.setOptions({ colors : [ '#803690', '#00ADF9', '#DCDCDC', '#46BFBD', '#FDB45C', '#949FB1', '#4D5360'] });
+  ChartJsProvider.setOptions({ colours : [ '#803690', '#00ADF9', '#DCDCDC', '#46BFBD', '#FDB45C', '#949FB1', '#4D5360'] });
 }); </code></pre></p>
     </section>
     <section id="directives">


### PR DESCRIPTION
<!-- Thanks for taking the time to submit a pull request for this project. Please ensure the following 
     before opening a pull request as best as you can. -->

### Description of change

I've just realized that the documentation refer `colors` instead of `colours`. I took a while to make work.

### Pull Request check-list

- [ ] Run `gulp test` to ensure there are no linting, or style issues and all tests pass.
- [ ] Squash your commits into a few commits only.
- [x] Make sure the commit message is short, concise and descriptive of the issues you're fixing.
- [ ] Avoid mixing up multiple issues and/or features, open one pull request for each issue.
- [x] Have you updated the documentation and / or examples?
- [ ] Have you included a new test?