### PR TITLE
More control to multiple Y-Axes (Chartjs 2.0)

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -281,7 +281,7 @@
             data: item
           });
           if (yaxis) {
-            dataset.yAxisID = 'y-axis-' + (i + 1);
+            dataset.yAxisID = yaxis[i];
           }
           return dataset;
         })

--- a/examples/app.js
+++ b/examples/app.js
@@ -36,7 +36,7 @@
         console.log('No point');
       }
     };
-    $scope.multiAxis = true;
+    $scope.multiAxis = ['y-axis-1', 'y-axis-2'];
 
     $scope.options = {
       scales: {


### PR DESCRIPTION
### #365 More control to multiple Y-Axes 

Changed chartYAxes to an array that matches to datasets by index.

Here first and third dataset would go to Y-Axis 1 and second to Y-Axis 2
chart-data = [[1,2,3], [4,5,6], [7,8,9]]
chart-y-axes = ['y-axis-1', 'y-axis-2', 'y-axis-1']

### Pull Request check-list

- [x] Run `gulp test` to ensure there are no linting, or style issues and all tests pass.
**[Some font differences in labels of .png files]**
- [x] Squash your commits into a few commits only.
- [x] Make sure the commit message is short, concise and descriptive of the issues you're fixing.
- [x] Avoid mixing up multiple issues and/or features, open one pull request for each issue.
- [x] Have you updated the documentation and / or examples?
- [ ] Have you included a new test?
