### PR TITLE
Chart.js 2.1.0 introduced support for horizontal bar charts. Update t…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "angular": "1.x",
-    "Chart.js": "~2.0.0"
+    "Chart.js": "~2.1.0"
   },
   "devDependencies": {
     "angular-bootstrap": "~0.11.0",

--- a/dist/angular-chart.js
+++ b/dist/angular-chart.js
@@ -43,6 +43,7 @@
     .directive('chartBase', ['ChartJsFactory', function (ChartJsFactory) { return new ChartJsFactory(); }])
     .directive('chartLine', ['ChartJsFactory', function (ChartJsFactory) { return new ChartJsFactory('line'); }])
     .directive('chartBar', ['ChartJsFactory', function (ChartJsFactory) { return new ChartJsFactory('bar'); }])
+    .directive('chartHorizontalBar', ['ChartJsFactory', function (ChartJsFactory) { return new ChartJsFactory('horizontalBar'); }])
     .directive('chartRadar', ['ChartJsFactory', function (ChartJsFactory) { return new ChartJsFactory('radar'); }])
     .directive('chartDoughnut', ['ChartJsFactory', function (ChartJsFactory) { return new ChartJsFactory('doughnut'); }])
     .directive('chartPie', ['ChartJsFactory', function (ChartJsFactory) { return new ChartJsFactory('pie'); }])


### PR DESCRIPTION
<!-- Thanks for taking the time to submit a pull request for this project. Please ensure the following 
     before opening a pull request as best as you can. -->

### Description of change

Chart.js 2.1.0 introduced support for horizontal bar charts. Update to chart.js 2.1.0 and add charttype horizontalBar

