### PR TITLE
add directive  chart-dataset-overload

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -100,7 +100,8 @@
           chartColors: '=?',
           chartClick: '=?',
           chartHover: '=?',
-          chartYAxes: '=?'
+          chartYAxes: '=?',
+          chartDatasetOverload: '=?'
         },
         link: function (scope, elem/*, attrs */) {
           var chart;
@@ -127,6 +128,7 @@
           scope.$watch('chartLabels', resetChart, true);
           scope.$watch('chartOptions', resetChart, true);
           scope.$watch('chartColors', resetChart, true);
+          scope.$watch('chartDatasetOverload', resetChart, true);
 
           scope.$watch('chartType', function (newVal, oldVal) {
             if (isEmpty(newVal)) return;
@@ -161,7 +163,7 @@
             var colors = getColors(type, scope);
             var cvs = elem[0], ctx = cvs.getContext('2d');
             var data = Array.isArray(scope.chartData[0]) ?
-              getDataSets(scope.chartLabels, scope.chartData, scope.chartSeries || [], colors, scope.chartYAxes) :
+              getDataSets(scope.chartLabels, scope.chartData, scope.chartSeries || [], colors, scope.chartYAxes, scope.chartDatasetOverload) :
               getData(scope.chartLabels, scope.chartData, colors);
 
             var options = angular.extend({}, ChartJs.getOptions(type), scope.chartOptions);
@@ -272,7 +274,7 @@
       return [r, g, b];
     }
 
-    function getDataSets (labels, data, series, colors, yaxis) {
+    function getDataSets (labels, data, series, colors, yaxis, datasetOverload) {
       return {
         labels: labels,
         datasets: data.map(function (item, i) {
@@ -282,6 +284,9 @@
           });
           if (yaxis) {
             dataset.yAxisID = yaxis[i];
+          }
+          if (datasetOverload) {
+            angular.merge(dataset,datasetOverload[i])
           }
           return dataset;
         })


### PR DESCRIPTION
<!-- Thanks for taking the time to submit a pull request for this project. Please ensure the following 
     before opening a pull request as best as you can. -->
We could not set the options included in the chart dataset. We could only set the global options thanks to the directive chart-options. Therfore we could not set an option  per chart like described in Issue https://github.com/jtblin/angular-chart.js/issues/370
<!-- Please provide a description of the change here. Indicate which issue it's referring to. -->
I added a directive chart-dataset-overload. If it is present, createChart will merge both the dataset and the data set overload at the final step of the dataset creation.

That's my first pull request with github !