### PR TITLE
#414 fill background color of tooltip block

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -244,7 +244,7 @@
         borderColor: rgba(color, 1),
         pointBackgroundColor: rgba(color, 1),
         pointBorderColor: '#fff',
-        pointHoverBackgroundColor: '#fff',
+        pointHoverBackgroundColor: rgba(color, 1),
         pointHoverBorderColor: rgba(color, 0.8)
       };
     }


### PR DESCRIPTION
### Description of change

With this fix, line chart tooltips now show colored blocks instead of white blocks.

