### PR TITLE
Updated bower.json file to use ChartJs 2.1.3 (or higher minor version).

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,6 @@ but must be set via standard options e.g. `ChartJsProvider.setOptions({ responsi
 
 ### bower
 
-Bower support has been dropped in Chart.js since version 2.2.0 but you can still use it with Bower thanks to bower-npm-resolver if needed but using npm is preferred.
-
-First, add the resolver in your .bowerrc file:
-
-    {
-      "resolvers": [
-        "bower-npm-resolver"
-      ]
-    }
-
-Then:
-
-    npm install -g bower-npm-resolver
     bower install --save angular-chart.js
 
 ### manually

--- a/bower.json
+++ b/bower.json
@@ -39,10 +39,10 @@
   ],
   "dependencies": {
     "angular": "1.x",
-    "chart.js": "npm:chart.js#2.x"
+    "Chart.js": "~2.1.6"
   },
   "overrides" : {
-    "chart.js": {
+    "Chart.js": {
       "main": [
         "dist/Chart.bundle.min.js"
       ]


### PR DESCRIPTION
### Description of change

Fixes #480 

Updated bower.json file to use ChartJs 2.1.3 (capital C), and only to upgrade minor version since 2.2.0 removes bower support, which allows installing via Bower.
Also updated ReadMe file with new bower installation guide.