### PR TITLE
fixed missing closing tag in line chart example

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,8 +209,8 @@
             <tab heading="Markup">
             <pre><code data-language="html">&lt;canvas id=&quot;line&quot; class=&quot;chart chart-line&quot; chart-data=&quot;data&quot;
 chart-labels=&quot;labels&quot; chart-series=&quot;series&quot; chart-options=&quot;options&quot;
-chart-dataset-override=&quot;datasetOverride&quot; chart-click=&quot;onClick&quot;
-&lt;/canvas&gt; </code></pre>
+chart-dataset-override=&quot;datasetOverride&quot; chart-click=&quot;onClick&quot;&gt;
+&lt;/canvas&gt;</code></pre>
             </tab>
             <tab heading="Javascript">
               <pre><code data-language="javascript">angular.module("app", ["chart.js"]).controller("LineCtrl", function ($scope) {


### PR DESCRIPTION
### Description of change

Added missing closing tag in line chart markup from [Getting started](http://jtblin.github.io/angular-chart.js/#getting_started)
