### PR TITLE
Added stronger check of initial preconditions (angularjs and Chart.js…

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -10,8 +10,11 @@
     define(['angular', 'chart'], factory);
   } else {
     // Browser globals
-    if (typeof angular === 'undefined' || typeof Chart === 'undefined')
+    if (typeof angular === 'undefined') {
+        throw new Error('AngularJS framework needs to be included, see https://angularjs.org/');
+    } else if (typeof Chart === 'undefined') {
       throw new Error('Chart.js library needs to be included, see http://jtblin.github.io/angular-chart.js/');
+    }
     factory(angular, Chart);
   }
 }(function (angular, Chart) {


### PR DESCRIPTION
When angular-chart.js is used inside a project, it needs angular.js framework (obviously) and Chart.js library. Depending on the bundle strategy (specially with grunt & gulp and their concat steps), it could be possible to make a mistake specifying the order of the dependencies.

When this occurs, if the angular.js is not loaded before, the angular-chart.js will throw the following message "Chart.js library needs to be included, see http://jtblin.github.io/angular-chart.js/" due to the OR operator in the if at line 13. If we split this, we won't waste time reviewing the dependencies of Chart.js instead of AngularJS. 