### PR TITLE
fixed typo in 'Line Chart' documentation

### DIFF
--- a/examples/charts.html
+++ b/examples/charts.html
@@ -177,7 +177,7 @@
                   <li><code>chart-series</code> (default: <code>[]</code>): series labels</li>
                   <li><code>chart-click</code> (optional): onclick event handler</li>
                   <li><code>chart-hover</code> (optional): onmousemove event handler</li>
-                  <li><code>chart-colors</code> (default to global colors): colors for the chart</li>
+                  <li><code>chart-colours</code> (default to global colors): colors for the chart</li>
                   <li><code>chart-dataset-override</code> (optional): override datasets individually</li>
                 </ul>
               </div>


### PR DESCRIPTION
chart-colors directive is not working so I found that you are using directive attr name 'chart-colours' not 'chart-colors'

<!-- Thanks for taking the time to submit a pull request for this project. Please ensure the following 
     before opening a pull request as best as you can. -->

### Description of change

<!-- Please provide a description of the change here. Indicate which issue it's referring to. -->

### Pull Request check-list

- [x] Run `gulp test` to ensure there are no linting, or style issues and all tests pass.
- [ ] Squash your commits into a few commits only.
- [x] Make sure the commit message is short, concise and descriptive of the issues you're fixing.
- [x] Avoid mixing up multiple issues and/or features, open one pull request for each issue.
- [x] Have you updated the documentation and / or examples?
- [ ] Have you included a new test?
