### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ but must be set via standard options e.g. `ChartJsProvider.setOptions({ responsi
 
 ### cdn
 
-    //cdn.jsdelivr.net/angular.chartjs/latest/angular-chart.min.js
+    https://cdn.jsdelivr.net/npm/angular-chart.js@latest/dist/angular-chart.min.js
 
 ### bower
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/angular-chart.js.

Feel free to ping me if you have any questions regarding this change.