### PR TITLE
Module not found: Error: Can't resolve 'chart' issue fix on windows

### DIFF
--- a/angular-chart.js
+++ b/angular-chart.js
@@ -7,7 +7,7 @@
       typeof Chart !== 'undefined' ? Chart : require('chart.js'));
   }  else if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['angular', 'chart'], factory);
+    define(['angular', 'chart.js'], factory);
   } else {
     // Browser globals
     if (typeof angular === 'undefined') {


### PR DESCRIPTION
### Description of change

This PR fixes the Module not found: Error: Can't resolve 'chart' in ''[Your working directory]\node_modules\angular-chart.js\dist' when we compile this package with webpack and babel on windows

### Pull Request check-list

- [X] Run `gulp test` to ensure there are no linting, or style issues and all tests pass.
- [X] Squash your commits into a few commits only.
- [X] Make sure the commit message is short, concise and descriptive of the issues you're fixing.
- [X] Avoid mixing up multiple issues and/or features, open one pull request for each issue.
- [ ] Have you updated the documentation and / or examples?
- [ ] Have you included a new test?
